### PR TITLE
[ 👋🏻 SignUp ] 토큰 재발급 기능 구현

### DIFF
--- a/components/Landing/LandingKatchupStart.tsx
+++ b/components/Landing/LandingKatchupStart.tsx
@@ -1,12 +1,12 @@
-import { signup } from "core/apis/auth";
-import { setTokens } from "core/apis/token";
-import { useRouter } from "next/router";
-import { IcGoogle } from "public/assets/icons";
-import { useEffect, useState } from "react";
-import { AuthInfo } from "types/auth";
+import { signup } from 'core/apis/auth';
+import { setTokens } from 'core/apis/token';
+import { useRouter } from 'next/router';
+import { IcGoogle } from 'public/assets/icons';
+import { useEffect, useState } from 'react';
+import { AuthInfo } from 'types/auth';
 
-import styled from "@emotion/styled";
-import { useGoogleLogin } from "@react-oauth/google";
+import styled from '@emotion/styled';
+import { useGoogleLogin } from '@react-oauth/google';
 
 const LandingKatchupStart = () => {
   const router = useRouter();

--- a/components/Landing/LandingKatchupStart.tsx
+++ b/components/Landing/LandingKatchupStart.tsx
@@ -1,4 +1,5 @@
 import { signup } from "core/apis/auth";
+import { setTokens } from "core/apis/token";
 import { useRouter } from "next/router";
 import { IcGoogle } from "public/assets/icons";
 import { useEffect, useState } from "react";
@@ -20,8 +21,7 @@ const LandingKatchupStart = () => {
   const handleSignup = async () => {
     if (googleAccessToken) {
       const { accessToken, refreshToken }: AuthInfo = await signup(googleAccessToken);
-      localStorage.setItem('accessToken', accessToken);
-      localStorage.setItem('refreshToken', refreshToken);
+      setTokens(accessToken, refreshToken);
       router.push('/input/main');
     }
   };

--- a/components/Landing/LandingKatchupStart.tsx
+++ b/components/Landing/LandingKatchupStart.tsx
@@ -1,11 +1,11 @@
-import { signup } from 'core/apis/auth';
-import { useRouter } from 'next/router';
-import { IcGoogle } from 'public/assets/icons';
-import { useEffect, useState } from 'react';
-import { AuthInfo } from 'types/auth';
+import { signup } from "core/apis/auth";
+import { useRouter } from "next/router";
+import { IcGoogle } from "public/assets/icons";
+import { useEffect, useState } from "react";
+import { AuthInfo } from "types/auth";
 
-import styled from '@emotion/styled';
-import { useGoogleLogin } from '@react-oauth/google';
+import styled from "@emotion/styled";
+import { useGoogleLogin } from "@react-oauth/google";
 
 const LandingKatchupStart = () => {
   const router = useRouter();
@@ -21,7 +21,7 @@ const LandingKatchupStart = () => {
     if (googleAccessToken) {
       const { accessToken, refreshToken }: AuthInfo = await signup(googleAccessToken);
       localStorage.setItem('accessToken', accessToken);
-      localStorage.setItem('refreshTocke', refreshToken);
+      localStorage.setItem('refreshToken', refreshToken);
       router.push('/input/main');
     }
   };

--- a/core/apis/auth.ts
+++ b/core/apis/auth.ts
@@ -10,9 +10,10 @@ export const signup = async (accessToken: string) => {
   }
 };
 
-export const getRefreshToken = async (accessToken: string, refreshToken: string) => {
+export const getRefreshToken = async () => {
   try {
-    const { data } = await client.post('/auth/token', { accessToken, refreshToken });
+    const { data } = await client.post('/auth/token');
+    console.log(data.data);
     return data.data;
   } catch (error) {
     console.error(error);

--- a/core/apis/auth.ts
+++ b/core/apis/auth.ts
@@ -1,4 +1,4 @@
-import { client } from "lib/axios";
+import { client } from 'lib/axios';
 
 export const signup = async (accessToken: string) => {
   try {

--- a/core/apis/auth.ts
+++ b/core/apis/auth.ts
@@ -12,7 +12,7 @@ export const signup = async (accessToken: string) => {
 
 export const getRefreshToken = async () => {
   try {
-    const { data } = await client.post('/auth/token');
+    const { data } = await client.get('/auth/token');
     console.log(data.data);
     return data.data;
   } catch (error) {

--- a/core/apis/auth.ts
+++ b/core/apis/auth.ts
@@ -9,13 +9,3 @@ export const signup = async (accessToken: string) => {
     console.error(error);
   }
 };
-
-export const getRefreshToken = async () => {
-  try {
-    const { data } = await client.get('/auth/token');
-    console.log(data.data);
-    return data.data;
-  } catch (error) {
-    console.error(error);
-  }
-};

--- a/core/apis/auth.ts
+++ b/core/apis/auth.ts
@@ -1,8 +1,18 @@
-import { client } from 'lib/axios';
+import { client } from "lib/axios";
 
 export const signup = async (accessToken: string) => {
   try {
     const { data } = await client.post('/auth', { accessToken });
+    console.log(data.data);
+    return data.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getRefreshToken = async (accessToken: string, refreshToken: string) => {
+  try {
+    const { data } = await client.post('/auth/token', { accessToken, refreshToken });
     return data.data;
   } catch (error) {
     console.error(error);

--- a/core/apis/token.ts
+++ b/core/apis/token.ts
@@ -18,6 +18,7 @@ const setAuthHeaders = (config: AxiosRequestConfig, accessToken: string, refresh
 const renewTokens = async (config: AxiosRequestConfig): Promise<void> => {
   try {
     const { data } = await client.get('/auth/token');
+    console.log(data);
 
     const newAccessToken = data.data.accessToken;
     const newRefreshToken = data.data.refreshToken;

--- a/core/apis/token.ts
+++ b/core/apis/token.ts
@@ -2,7 +2,6 @@ import { AxiosRequestConfig } from "axios";
 import { client } from "lib/axios";
 
 const getAccessToken = () => localStorage.getItem('accessToken') || '';
-
 const getRefreshToken = () => localStorage.getItem('refreshToken') || '';
 
 const setTokens = (accessToken: string, refreshToken: string) => {
@@ -16,14 +15,15 @@ const setAuthHeaders = (config: AxiosRequestConfig, accessToken: string, refresh
   return config;
 };
 
-const renewTokens = async (config: AxiosRequestConfig): Promise<AxiosRequestConfig | undefined> => {
+const renewTokens = async (config: AxiosRequestConfig): Promise<void> => {
   try {
     const { data } = await client.get('/auth/token');
+
     const newAccessToken = data.data.accessToken;
     const newRefreshToken = data.data.refreshToken;
-    setTokens(newAccessToken, newRefreshToken);
 
-    return setAuthHeaders(config, newAccessToken, newRefreshToken);
+    setTokens(newAccessToken, newRefreshToken);
+    setAuthHeaders(config, newAccessToken, newRefreshToken);
   } catch (err) {
     console.error('Error renewing token:', err);
     window.location.href = '/';

--- a/core/apis/token.ts
+++ b/core/apis/token.ts
@@ -1,5 +1,5 @@
-import { AxiosRequestConfig } from "axios";
-import { client } from "lib/axios";
+import { AxiosRequestConfig } from 'axios';
+import { client } from 'lib/axios';
 
 const getAccessToken = () => localStorage.getItem('accessToken') || '';
 const getRefreshToken = () => localStorage.getItem('refreshToken') || '';

--- a/core/apis/token.ts
+++ b/core/apis/token.ts
@@ -1,0 +1,33 @@
+import { AxiosRequestConfig } from "axios";
+import { client } from "lib/axios";
+
+const getAccessToken = () => localStorage.getItem('accessToken') || '';
+
+const getRefreshToken = () => localStorage.getItem('refreshToken') || '';
+
+const setTokens = (accessToken: string, refreshToken: string) => {
+  localStorage.setItem('accessToken', accessToken);
+  localStorage.setItem('refreshToken', refreshToken);
+};
+
+const setAuthHeaders = (config: AxiosRequestConfig, accessToken: string, refreshToken: string): AxiosRequestConfig => {
+  config.headers!.Authorization = `Bearer ${accessToken}`;
+  config.headers!.Refresh = refreshToken;
+  return config;
+};
+
+const renewTokens = async (config: AxiosRequestConfig): Promise<AxiosRequestConfig | undefined> => {
+  try {
+    const { data } = await client.get('/auth/token');
+    const newAccessToken = data.data.accessToken;
+    const newRefreshToken = data.data.refreshToken;
+    setTokens(newAccessToken, newRefreshToken);
+
+    return setAuthHeaders(config, newAccessToken, newRefreshToken);
+  } catch (err) {
+    console.error('Error renewing token:', err);
+    window.location.href = '/';
+  }
+};
+
+export { getAccessToken, getRefreshToken, setTokens, setAuthHeaders, renewTokens };

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,10 +1,5 @@
-import axios from "axios";
-import {
-  getAccessToken,
-  getRefreshToken,
-  renewTokens,
-  setAuthHeaders
-} from "core/apis/token";
+import axios from 'axios';
+import { getAccessToken, getRefreshToken, renewTokens, setAuthHeaders } from 'core/apis/token';
 
 const client = axios.create({
   baseURL: process.env.NEXT_PUBLIC_APP_IP,

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -19,5 +19,38 @@ client.interceptors.request.use((config) => {
   return config;
 });
 
+client.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  async (error) => {
+    const { config, response } = error;
+    const originalRequest = config;
+    console.log(config, response);
+
+    //token 만료
+    if (response.status === 401) {
+      console.log(response);
+
+      const res = await client.get('/auth/token'); // token 재발급 api
+      console.log(res.data);
+
+      if (res.data.status === 400) {
+        window.location.href = '/';
+        return;
+      }
+      const newAccessToken = res.data.data.accessToken;
+      const newRefreshToken = res.data.data.refreshToken;
+      localStorage.setItem('accessToken', newAccessToken);
+      localStorage.setItem('refreshToken', newRefreshToken);
+
+      originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      originalRequest.headers.Refresh = newRefreshToken;
+      return axios(originalRequest);
+    }
+    return error.response;
+  },
+);
+
 export const katchupGetFetcher = (url: string) => client.get(url).then((res) => res.data);
 export { client };

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from "axios";
 
 const client = axios.create({
   baseURL: process.env.NEXT_PUBLIC_APP_IP,
@@ -9,9 +9,12 @@ const client = axios.create({
 });
 
 client.interceptors.request.use((config) => {
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  const accessToken = localStorage.getItem('accessToken');
+  const refreshToken = localStorage.getItem('refreshToken');
+
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+    config.headers.Refresh = refreshToken;
   }
   return config;
 });

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -32,11 +32,9 @@ client.interceptors.response.use(
     const { config, response } = error;
 
     // 리프레시 토큰도 만료된 경우 재로그인
-    if (response.status === 401) {
-      if (response.data.status === 'KC-204') {
-        window.location.href = '/';
-        return;
-      }
+    if (response?.status === 401 && response?.data?.status === 'KC-204') {
+      window.location.href = '/';
+      return;
     }
     renewTokens(config);
 


### PR DESCRIPTION
## 🔥 Related Issues

resolved #69 

## 💜 작업 내용

- [x] 인터셉터로 엑세스 토큰 만료 시 토큰 재발급 기능 구현
- [x] 토큰 저장, 재발급 관련 함수 분리

## ✅ PR Point

- `token.ts` 파일에 토큰 로컬스토리지에 저장, 가져오기, 헤더 저장, 토큰 재발급 함수 분리해서 모듈화했습니다.
- `axios.ts` 파일에서 인터셉터로 토큰 헤더에 저장, 엑세스 토큰 만료 시 재발급, 리프레시 토큰 만료 시 재로그인 할 수 있도록 구현했습니다.
- 유효시간은 엑세스토큰 -> 10분, 리프레시토큰 -> 30분 입니다!! 30분 지나면 다시 구글 로그인 해야 돼요 개발할때 참고하시길,,, 

## 👀 스크린샷 / GIF / 링크
- 1. 구글 로그인 시, 2. 토큰 재발급 시 확인용으로 콘솔로 찍히게 해뒀어요 불편하면 지워도됨!!!
